### PR TITLE
Made threshold a field

### DIFF
--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -113,8 +113,17 @@
             "uid": "influxdb"
           },
           "hide": false,
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\" or r[\"_field\"] == \"Threshold\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n  |> group(columns: [\"machine\"])\n  \n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)\n  |> yield(name: \"mean\")\n\n",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "influxdb"
+          },
+          "hide": false,
+          "query": "from(bucket: \"temperature_monitoring\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\r\n\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Threshold\")\r\n  |> group(columns: [\"Threshold\"])\r\n\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)\r\n  |> yield(name: \"mean\")",
+          "refId": "B"
         }
       ],
       "title": "Temperature History",
@@ -131,9 +140,7 @@
             "excludeByName": {},
             "indexByName": {},
             "renameByName": {
-              "Threshold {machine=\"MyRD2\", name=\"temperature_reading\", sensor=\"PT100_raspi_MAX31865\"}": "Threshold",
-              "Time": "",
-              "temp {machine=\"MyRD2\", name=\"temperature_reading\", sensor=\"PT100_raspi_MAX31865\"}": "Temperature"
+              "Value 2": "Threshold"
             }
           }
         }
@@ -437,13 +444,13 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -420,33 +420,33 @@
     "list": [
       {
         "current": {
-          "selected": true,
-          "text": "Machine_1",
-          "value": "Machine_1"
+          "selected": false,
+          "text": "MyRD2",
+          "value": "MyRD2"
         },
         "hide": 0,
         "name": "machine",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "Machine_1",
             "value": "Machine_1"
           }
         ],
-        "query": "Machine_1",
+        "query": "MyRD2",
         "skipUrlSync": false,
         "type": "textbox"
       }
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -113,31 +113,28 @@
             "uid": "influxdb"
           },
           "hide": false,
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> group(columns: [\"machine\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\" or r[\"_field\"] == \"Threshold\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)\n  |> yield(name: \"mean\")",
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "influxdb"
-          },
-          "hide": false,
-          "query": "from(bucket: \"temperature_monitoring\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\r\n  |> group(columns: [\"machine\"])\r\n  |> keep(columns: [\"Threshold\",\"_time\"])\r\n",
-          "refId": "B"
         }
       ],
       "title": "Temperature History",
       "transformations": [
         {
-          "id": "convertFieldType",
+          "id": "joinByField",
           "options": {
-            "conversions": [
-              {
-                "destinationType": "number",
-                "targetField": "Threshold"
-              }
-            ],
-            "fields": {}
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Threshold {machine=\"MyRD2\", name=\"temperature_reading\", sensor=\"PT100_raspi_MAX31865\"}": "Threshold",
+              "Time": "",
+              "temp {machine=\"MyRD2\", name=\"temperature_reading\", sensor=\"PT100_raspi_MAX31865\"}": "Temperature"
+            }
           }
         }
       ],
@@ -231,7 +228,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> group(columns: [\"machine\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -403,7 +400,7 @@
             "type": "influxdb",
             "uid": "influxdb"
           },
-          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AlertVal\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> group(columns: [\"machine\"])\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
+          "query": "from(bucket: \"temperature_monitoring\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\n  |> filter(fn: (r) => r[\"_field\"] == \"AlertVal\")\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\n  |> aggregateWindow(every: v.windowPeriod, fn: last, createEmpty: false)\n  |> yield(name: \"last\")",
           "refId": "A"
         }
       ],
@@ -428,9 +425,9 @@
         "name": "machine",
         "options": [
           {
-            "selected": false,
-            "text": "Machine_1",
-            "value": "Machine_1"
+            "selected": true,
+            "text": "MyRD2",
+            "value": "MyRD2"
           }
         ],
         "query": "MyRD2",
@@ -440,13 +437,13 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -418,19 +418,19 @@
       {
         "current": {
           "selected": false,
-          "text": "MyRD2",
-          "value": "MyRD2"
+          "text": "",
+          "value": ""
         },
         "hide": 0,
         "name": "machine",
         "options": [
           {
             "selected": true,
-            "text": "MyRD2",
-            "value": "MyRD2"
+            "text": "",
+            "value": ""
           }
         ],
-        "query": "MyRD2",
+        "query": "",
         "skipUrlSync": false,
         "type": "textbox"
       }
@@ -444,6 +444,6 @@
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/timeseries_sds/config/telegraf.conf
+++ b/timeseries_sds/config/telegraf.conf
@@ -8,30 +8,6 @@ flush_jitter = "2s"
 
 omit_hostname = true
 
-# [[inputs.serial]]
-#   ## Serial port to collect data
-#   serial_port = "/dev/ttyACM0" # Change this to your serial port name
-#   baud_rate = 115200
-#   data_format = "json" # or whatever your data format is
-
-#   	[[inputs.serial.json_v2]]
-# 		measurement_name = "temperature_reading"
-# 		# A string with valid GJSON path syntax, will override measurement_name
-# 		#measurement_name_path = "status" 		
-
-# 		# A string with valid GJSON path syntax to a valid timestamp (single value)
-# 		# timestamp_path = "timestamp"
-		
-# 		# A string with a valid timestamp format (see below for possible values)
-# 		# timestamp_format = "2006-01-02T15:04:05.999-07:00" 
-# 	[[inputs.serial.json_v2.field]]
-# 		path = "T" # A string with valid GJSON path syntax
-# 		type = "float"
-# 	[[inputs.serial.json_v2.field]]
-# 		path = "R" # A string with valid GJSON path syntax
-# 		type = "float"
-
-
 
 [[inputs.mqtt_consumer]]
 servers = ["tcp://mqtt.docker.local:1883"]

--- a/timeseries_sds/config/telegraf.conf
+++ b/timeseries_sds/config/telegraf.conf
@@ -19,27 +19,29 @@ qos = 1
 	[[inputs.mqtt_consumer.json_v2]]
 		measurement_name = "temperature_reading"
 		# A string with valid GJSON path syntax, will override measurement_name
-		#measurement_name_path = "status" 		
+		#measurement_name_path = "status"
 
 		# A string with valid GJSON path syntax to a valid timestamp (single value)
 		timestamp_path = "timestamp"
-		
 		# A string with a valid timestamp format (see below for possible values)
-		timestamp_format = "2006-01-02T15:04:05.999-07:00" 
+		timestamp_format = "2006-01-02T15:04:05.999-07:00"
+
 		[[inputs.mqtt_consumer.json_v2.field]]
 			path = "temp" # A string with valid GJSON path syntax
 			type = "float"
+
 		[[inputs.mqtt_consumer.json_v2.field]]
 			path = "AlertVal" # A string with valid GJSON path syntax
 			type = "float"
-		
-		[[inputs.mqtt_consumer.json_v2.tag]]
-			path = "machine" # A string with valid GJSON path syntax
-			type = "string"
 
 		[[inputs.mqtt_consumer.json_v2.field]]
 			path = "Threshold" # A string with valid GJSON path syntax
 			type = "float"
+
+
+		[[inputs.mqtt_consumer.json_v2.tag]]
+			path = "machine" # A string with valid GJSON path syntax
+			type = "string"
 
 		[[inputs.mqtt_consumer.json_v2.tag]]
 			path = "sensor" # A string with valid GJSON path syntax

--- a/timeseries_sds/config/telegraf.conf
+++ b/timeseries_sds/config/telegraf.conf
@@ -37,7 +37,7 @@ qos = 1
 			path = "machine" # A string with valid GJSON path syntax
 			type = "string"
 
-		[[inputs.mqtt_consumer.json_v2.tag]]
+		[[inputs.mqtt_consumer.json_v2.field]]
 			path = "Threshold" # A string with valid GJSON path syntax
 			type = "float"
 


### PR DESCRIPTION
Finally making the threshold value and alert status an InfluxDB field (rather than a tag). Fixes #17 

- A machine can have only one threshold and alertval at once, but these can change over time. Hence they are timeseries data. Hence they are best stored as a field.
- The threshold value being a tag does cause trouble ( see #17, #22 )