### PR TITLE
Feature/low threshold

### DIFF
--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -43,7 +43,6 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "axisSoftMin": 0,
             "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 0,
@@ -122,8 +121,17 @@
             "uid": "influxdb"
           },
           "hide": false,
-          "query": "from(bucket: \"temperature_monitoring\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\r\n\r\n  |> filter(fn: (r) => r[\"_field\"] == \"Threshold\")\r\n  |> group(columns: [\"Threshold\"])\r\n\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)\r\n  |> yield(name: \"mean\")",
+          "query": "from(bucket: \"temperature_monitoring\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\r\n\r\n  |> filter(fn: (r) => r[\"_field\"] == \"ThresholdHigh\")\r\n  |> group(columns: [\"ThresholdHigh\"])\r\n\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)\r\n  |> yield(name: \"mean\")",
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "influxdb"
+          },
+          "hide": false,
+          "query": "from(bucket: \"temperature_monitoring\")\r\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\r\n  |> filter(fn: (r) => r[\"_measurement\"] == \"temperature_reading\")\r\n  |> filter(fn: (r) => r[\"machine\"] == \"${machine}\")\r\n\r\n  |> filter(fn: (r) => r[\"_field\"] == \"ThresholdLow\")\r\n  |> group(columns: [\"ThresholdLow\"])\r\n\r\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: true)\r\n  |> yield(name: \"mean\")",
+          "refId": "C"
         }
       ],
       "title": "Temperature History",
@@ -140,7 +148,8 @@
             "excludeByName": {},
             "indexByName": {},
             "renameByName": {
-              "Value 2": "Threshold"
+              "Value 2": "High Threshold",
+              "Value 3": "Low Threshold"
             }
           }
         }
@@ -270,7 +279,7 @@
                 "value": 0
               },
               {
-                "color": "red",
+                "color": "dark-red",
                 "value": 1
               }
             ]
@@ -347,13 +356,18 @@
               "options": {
                 "0": {
                   "color": "semi-dark-green",
-                  "index": 0,
+                  "index": 1,
                   "text": "OK"
                 },
                 "1": {
                   "color": "dark-red",
-                  "index": 1,
+                  "index": 2,
                   "text": "HIGH"
+                },
+                "-1": {
+                  "color": "dark-blue",
+                  "index": 0,
+                  "text": "LOW"
                 }
               },
               "type": "value"
@@ -444,13 +458,13 @@
     ]
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 4,
+  "version": 2,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -294,7 +294,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": "Alert"
+                "value": ""
               }
             ]
           }

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -340,7 +340,7 @@
             "properties": [
               {
                 "id": "displayName",
-                "value": ""
+                "value": "  "
               }
             ]
           }
@@ -511,6 +511,6 @@
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }

--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -84,7 +84,53 @@
           },
           "unit": "celsius"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "High Threshold"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Low Threshold"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Incubator"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 9,
@@ -465,6 +511,6 @@
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 2,
+  "version": 4,
   "weekStart": ""
 }

--- a/temperature_dc/code/measure.py
+++ b/temperature_dc/code/measure.py
@@ -65,11 +65,7 @@ class TemperatureMeasureBuildingBlock(multiprocessing.Process):
         self.collection_interval = config['sampling']['sample_interval']
         self.sample_count = config['sampling']['sample_count']
 
-       
 
-        # logger.info("TemperatureMeasureBuildingBlock- STAGE-1 done")
-        # self.sensor = config['sensing']['adc']
-        # self.Threshold = config['threshold']['th1']                # User sets the threshold in the config file
 
     def do_connect(self):
         self.zmq_out = context.socket(self.zmq_conf['type'])
@@ -93,17 +89,6 @@ class TemperatureMeasureBuildingBlock(multiprocessing.Process):
         run = True
         period = self.collection_interval
 
-        # get correct ADC module
-        #try:
-        #    adc_module = importlib.import_module(f"adc.{self.adc_module}")
-        #    logger.debug(f"Imported {self.adc_module}")
-        #except ModuleNotFoundError as e:
-        #    logger.error(f"Unable to import module {self.adc_module}. Stopping!!")
-        #    return
-
-        #adc = adc_module.ADC(self.config)
-
-        #---------------- TEST MODULE 2 -------------------
 
         Threshold = float(self.config['threshold']['th1'])                # User sets the threshold in the config file
 
@@ -175,7 +160,6 @@ class TemperatureMeasureBuildingBlock(multiprocessing.Process):
                 timestamp = datetime.datetime.now(tz=tz).isoformat()
 
                 # convert
-                # results = calculation.calculate(average_sample)
                 # payload = {**results, **self.constants, "timestamp": timestamp}
                 payload = {"machine": self.constants['machine'], "temp": average_sample, "AlertVal": AlertVal, "Threshold": Threshold, "sensor": self.config['sensing']['adc'], "timestamp": timestamp}
 

--- a/temperature_dc/code/measure.py
+++ b/temperature_dc/code/measure.py
@@ -90,7 +90,10 @@ class TemperatureMeasureBuildingBlock(multiprocessing.Process):
         period = self.collection_interval
 
 
-        Threshold = float(self.config['threshold']['th1'])                # User sets the threshold in the config file
+        # Load user-set thresholds from the config file
+        th_low = float(self.config['threshold']['low'])
+        th_high = float(self.config['threshold']['high'])
+
 
         if self.config['sensing']['adc'] == 'MLX90614':
             sensor = sen.MLX90614()
@@ -151,8 +154,11 @@ class TemperatureMeasureBuildingBlock(multiprocessing.Process):
                 print(average_sample)
                 logger.info(f"temperature_reading: {average_sample}")
 
-                if average_sample > Threshold:
+                # Compare against thresholds 
+                if average_sample > th_high:
                     AlertVal = 1
+                elif average_sample < th_low:
+                    AlertVal = -1
                 else:
                     AlertVal = 0
 
@@ -161,7 +167,7 @@ class TemperatureMeasureBuildingBlock(multiprocessing.Process):
 
                 # convert
                 # payload = {**results, **self.constants, "timestamp": timestamp}
-                payload = {"machine": self.constants['machine'], "temp": average_sample, "AlertVal": AlertVal, "Threshold": Threshold, "sensor": self.config['sensing']['adc'], "timestamp": timestamp}
+                payload = {"machine": self.constants['machine'], "temp": average_sample, "AlertVal": AlertVal, "ThresholdLow": th_low, "ThresholdHigh": th_high, "sensor": self.config['sensing']['adc'], "timestamp": timestamp}
 
                 # send
                 output = {"path": "", "payload": payload}

--- a/temperature_dc/config/config.toml
+++ b/temperature_dc/config/config.toml
@@ -1,8 +1,9 @@
 [constants]
     machine="Machine_1"	#Name of the machine being monitored (can't have spaces)
 
-[threshold]
-    th1 = 50  #for 1 sensor
+[threshold] # in degrees C
+    low = 25
+    high = 30 
 
 [sensing]
     # uncomment (remove the leading #) from the sensor that you are using:

--- a/timeseries_sds/config/telegraf.conf
+++ b/timeseries_sds/config/telegraf.conf
@@ -35,7 +35,11 @@ qos = 1
 			type = "float"
 
 		[[inputs.mqtt_consumer.json_v2.field]]
-			path = "Threshold" # A string with valid GJSON path syntax
+			path = "ThresholdLow" # A string with valid GJSON path syntax
+			type = "float"
+
+		[[inputs.mqtt_consumer.json_v2.field]]
+			path = "ThresholdHigh" # A string with valid GJSON path syntax
 			type = "float"
 
 


### PR DESCRIPTION
Why not have dual thresholds for the temperature value?

![image](https://github.com/user-attachments/assets/9ffd73cb-0f64-401f-956b-77c3d4d3bd18)

The config file now goes:
```
[threshold] # in degrees C
    low = 25
    high = 30 
```

This also removes the need for a partially hardcoded scale on the graph (introduced in #16 to give the distance between the lines meaning) as the spacing between the two thresholds will prevent the autoscale from zooming in too much.

The Red/Green/Blue colours have been fixed.