### PR TITLE
Dropdown for machine names 

### DIFF
--- a/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
+++ b/dashboard_ui/config/dashboards/Temperature Monitoring/dashboard.json
@@ -485,21 +485,25 @@
       {
         "current": {
           "selected": false,
-          "text": "",
-          "value": ""
+          "text": "None",
+          "value": "None"
         },
+        "datasource": {
+          "type": "influxdb",
+          "uid": "influxdb"
+        },
+        "definition": "from(bucket: \"temperature_monitoring\")\r\n  |> range(start: -30d)\r\n  |> keep(columns: [\"machine\"])\r\n  |> distinct(column: \"machine\")\r\n  |> filter(fn: (r) => r[\"machine\"] != \"null\")\r\n  |> group()",
         "hide": 0,
+        "includeAll": false,
+        "multi": false,
         "name": "machine",
-        "options": [
-          {
-            "selected": true,
-            "text": "",
-            "value": ""
-          }
-        ],
-        "query": "",
+        "options": [],
+        "query": "from(bucket: \"temperature_monitoring\")\r\n  |> range(start: -30d)\r\n  |> keep(columns: [\"machine\"])\r\n  |> distinct(column: \"machine\")\r\n  |> filter(fn: (r) => r[\"machine\"] != \"null\")\r\n  |> group()",
+        "refresh": 1,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "textbox"
+        "sort": 0,
+        "type": "query"
       }
     ]
   },
@@ -511,6 +515,6 @@
   "timezone": "",
   "title": "Temperature_starter_solution",
   "uid": "70aiGq34k",
-  "version": 5,
+  "version": 6,
   "weekStart": ""
 }


### PR DESCRIPTION
Like many Shoestring dashboards, after this there will be a dropdown variable in the top left for the machine name

I have concerns about old machines not appearing in the dropdown (query only finds those active in the last 30 days) 
but also that this query checks every single data point in the last 30 days - any more and it may timeout. 

We can fine tune the balance later, for now 30 days is close enough to acceptable on both sides.