### PR TITLE
Support for loading config file from env in main.py

### DIFF
--- a/temperature_dc/code/main.py
+++ b/temperature_dc/code/main.py
@@ -37,6 +37,7 @@ import tomli
 import time
 import logging
 import zmq
+import os # for fetching environment variables
 # local
 import measure
 import wrapper
@@ -45,8 +46,15 @@ logger = logging.getLogger("main")
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')  # move to log config file using python functionality
 
 
-def get_config():
-    with open("./config/config.toml", "rb") as f:
+def get_config(env_var="CONFIG_FILE", default_file_path="./config/config.toml"):
+
+    env_file_path = os.getenv(env_var)
+    if env_file_path:
+        config_file_path = env_file_path
+    else:
+        config_file_path = default_file_path
+        
+    with open(config_file_path, "rb") as f:
         toml_conf = tomli.load(f)
     logger.info(f"config:{toml_conf}")
     return toml_conf

--- a/temperature_dc/code/main.py
+++ b/temperature_dc/code/main.py
@@ -48,12 +48,15 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(level
 
 def get_config(env_var="CONFIG_FILE", default_file_path="./config/config.toml"):
 
-    env_file_path = os.getenv(env_var)
+    # If an environment variable is set with the specified key, use it as the path to the config file
+    env_file_path = os.getenv(env_var) # returns None if env var not set
     if env_file_path:
         config_file_path = env_file_path
+    # If no such environment variable, failover to using specified string directly
     else:
         config_file_path = default_file_path
-        
+
+    # Open the file, parse the contents as toml and return as dictionary
     with open(config_file_path, "rb") as f:
         toml_conf = tomli.load(f)
     logger.info(f"config:{toml_conf}")


### PR DESCRIPTION
Allow creating an environment variable (in docker compose) to specify the path to the config file, rather than it being a hardcoded constant.

This allows monitoring multiple machines at once on the same hardware by running multiple sensing docker containers configured in different ways, in a similar way that can be done with power.