### PR TITLE
Bugfix/max31865 calibration and external RTD model

### DIFF
--- a/temperature_dc/code/adc/MAX31865.py
+++ b/temperature_dc/code/adc/MAX31865.py
@@ -38,9 +38,9 @@ class max31865:
 	REG_RTD_READING = 0x01
 
 
-	def __init__(self, R_Ref=438, spi_bus=0, spi_cs=1, spi_speed=7629, spi_clock_polarity=1, spi_clock_phase=1):
+	def __init__(self, R_Ref=430, spi_bus=0, spi_cs=1, spi_speed=7629, spi_clock_polarity=1, spi_clock_phase=1):
 
-		self.R_Ref = R_Ref	# ADC full scale. Ideally around 4*R_0dC. Our board's resistor is marked 431 => 430 ohms, but measuring it suggests 438.
+		self.R_Ref = R_Ref	# ADC full scale. Ideally around 4*R_0dC. Product we recommend is specified to have a 430Ω 0.1% resistor.
 
 		self.spi = spidev.SpiDev()
 		self.spi.open(spi_bus, spi_cs)

--- a/temperature_dc/code/adc/MAX31865.py
+++ b/temperature_dc/code/adc/MAX31865.py
@@ -27,7 +27,6 @@
 # ----------------------------------------------------------------------
 
 import spidev
-from math import sqrt
 import time
 
 class max31865:
@@ -119,53 +118,16 @@ class max31865:
 		return R_RTD
 
 
-class PT_RTD:
-
-	def __init__(self, R_0dC, a=3.9083e-3, b=-5.775e-7, c_pos=0, c_neg=-4.18301e-12):
-
-		self.R_0dC = R_0dC	# The RTD resistance at 0 degrees C. Common standards are 100 and 1000.
-
-		# A great model of PT-RTD resistance vs temperature is the Callendar-Van Dusen equation:
-		# R_RTD = R_0dC * (1 + a*T + b*T**2 + c*(T-100)*T**3)
-		# Standard constants (IEC7751/SAMA) as default
-
-		self.a = a
-		self.b = b
-		self.c_pos = c_pos	# For temperatures above 0 degrees C
-		self.c_neg = c_neg	# For temperatures below 0 degrees C
-
-
-	def __call__(self, resistance):
-		"""shorthand for most common usage"""
-		return self.calculate_temperature_quadratic(resistance)
-
-
-	def calculate_temperature_linear(self, resistance):
-
-		# Linear approximation:
-		T_C_linear = ((resistance / self.R_0dC) - 1) / self.a
-		return T_C_linear
-
-	def calculate_temperature_quadratic(self, resistance):
-
-		# Quadratic approximation (unfortunately the constants do not follow convention):
-		# R_RTD / R_0dC = 1 + aT + bt^2
-		# T = (-a +- sqrt(a^2-4b(1-R_RTD/R_0dC))) / 2b
-		T_C_quadratic = ( -self.a + sqrt((self.a**2)-4*self.b*(1-(resistance/self.R_0dC))) )/(2*self.b)
-		return T_C_quadratic
-
-#	def calculate_temperature_quartic(self, resistance):
-		# Full Callendar-Van Dussen, improves on quad below 0dC.
-		# tbd
-
 
 # test
 if __name__ == '__main__':
+    
+	import models.pt_rtd
+	MyRTD = models.pt_rtd.PT_RTD(100)
 
 	MyMax = max31865()
 	MyMax.set_config(VBias=1, filter50Hz=1)
 	time.sleep(0.5)
-	MyRTD = PT_RTD(100)
 
 	# test in oneshot mode
 	print("oneshot mode:")

--- a/temperature_dc/code/adc/MAX31865.py
+++ b/temperature_dc/code/adc/MAX31865.py
@@ -41,6 +41,12 @@ class max31865:
 
 		self.R_Ref = R_Ref	# ADC full scale. Ideally around 4*R_0dC. Product we recommend is specified to have a 430Ω 0.1% resistor.
 
+		# validate channel
+		if not isinstance(spi_cs, int):
+			raise TypeError("channel is interpreted as chip select for MAX31865. Must be an integer. Received " + str(spi_cs) + ", a " + str(type(spi_cs)) +", from config")
+        if spi_cs < 0 or > 1:
+            raise ValueError("channel is interpreted as chip select for MAX31865. Must be 0 or 1. Received " + str(spi_cs)")
+
 		self.spi = spidev.SpiDev()
 		self.spi.open(spi_bus, spi_cs)
 		self.spi.max_speed_hz = spi_speed

--- a/temperature_dc/code/adc/MAX31865.py
+++ b/temperature_dc/code/adc/MAX31865.py
@@ -31,126 +31,126 @@ import time
 
 class max31865:
 
-	# Register definitions
-	REG_CONFIG_READ = 0x00
-	REG_CONFIG_WRITE = 0x80
-	REG_RTD_READING = 0x01
+    # Register definitions
+    REG_CONFIG_READ = 0x00
+    REG_CONFIG_WRITE = 0x80
+    REG_RTD_READING = 0x01
 
 
-	def __init__(self, R_Ref=430, spi_bus=0, spi_cs=1, spi_speed=7629, spi_clock_polarity=1, spi_clock_phase=1):
+    def __init__(self, R_Ref=430, spi_bus=0, spi_cs=1, spi_speed=7629, spi_clock_polarity=1, spi_clock_phase=1):
 
-		self.R_Ref = R_Ref	# ADC full scale. Ideally around 4*R_0dC. Product we recommend is specified to have a 430Ω 0.1% resistor.
+        self.R_Ref = R_Ref	# ADC full scale. Ideally around 4*R_0dC. Product we recommend is specified to have a 430Ω 0.1% resistor.
 
-		# validate channel
-		if not isinstance(spi_cs, int):
-			raise TypeError("channel is interpreted as chip select for MAX31865. Must be an integer. Received " + str(spi_cs) + ", a " + str(type(spi_cs)) +", from config")
-        if spi_cs < 0 or > 1:
-            raise ValueError("channel is interpreted as chip select for MAX31865. Must be 0 or 1. Received " + str(spi_cs)")
+        # validate channel
+        if not isinstance(spi_cs, int):
+            raise TypeError("channel is interpreted as chip select for MAX31865. Must be an integer. Received " + str(spi_cs) + ", a " + str(type(spi_cs)) +", from config")
+        if spi_cs < 0 or spi_cs > 1:
+            raise ValueError("channel is interpreted as chip select for MAX31865. Must be 0 or 1. Received " + str(spi_cs))
 
-		self.spi = spidev.SpiDev()
-		self.spi.open(spi_bus, spi_cs)
-		self.spi.max_speed_hz = spi_speed
-		self.spi.mode = (spi_clock_polarity << 1 | spi_clock_phase)	# 0b11 or else...
-
-
-	def __call__(self):
-		return self.calculate_resistance(self._read_adc())
+        self.spi = spidev.SpiDev()
+        self.spi.open(spi_bus, spi_cs)
+        self.spi.max_speed_hz = spi_speed
+        self.spi.mode = (spi_clock_polarity << 1 | spi_clock_phase)	# 0b11 or else...
 
 
-	def _read_regs(self, first_reg_addr,  nregs=8):
-		"""Read nregs consecutive registers, starting from first_reg_addr"""
-
-		"""
-		A note on the registers of the MAX31865:
-		00h = Config
-		01h = RTD MSBs
-		02h = RTD LSBs
-		03h = High Fault Threshold MSB
-		04h = High Fault Threshold LSB
-		05h = Low Fault Threshold MSB
-		06h = Low Fault Threshold LSB
-		07h = Fault Status
-		"""
-
-		resp = self.spi.xfer2([first_reg_addr] + [0]*nregs)[1:] # Ignore first byte as it was while the command was being clocked in
-		return resp
+    def __call__(self):
+        return self.calculate_resistance(self._read_adc())
 
 
-	def _write_reg(self, reg_addr, data):
-		self.spi.writebytes([reg_addr, data])			# Can be temperamental and cause seg faults, but behaving today.
-#		self.spi.xfer2([reg_addr, data])			# More reliable, even when discarding the response.
+    def _read_regs(self, first_reg_addr,  nregs=8):
+        """Read nregs consecutive registers, starting from first_reg_addr"""
+
+        """
+        A note on the registers of the MAX31865:
+        00h = Config
+        01h = RTD MSBs
+        02h = RTD LSBs
+        03h = High Fault Threshold MSB
+        04h = High Fault Threshold LSB
+        05h = Low Fault Threshold MSB
+        06h = Low Fault Threshold LSB
+        07h = Fault Status
+        """
+
+        resp = self.spi.xfer2([first_reg_addr] + [0]*nregs)[1:] # Ignore first byte as it was while the command was being clocked in
+        return resp
 
 
-	def _bytes_to_15bit(self, MSBs_byte, LSBs_byte):
-		"""extract a 15bit int from two bytes, MSB justified"""
-		return ((MSBs_byte <<8 | LSBs_byte) >> 1)
+    def _write_reg(self, reg_addr, data):
+        self.spi.writebytes([reg_addr, data])		# Can be temperamental and cause seg faults, but behaving today.
+        #self.spi.xfer2([reg_addr, data])			# More reliable, even when discarding the response.
 
 
-	def _read_adc(self):
-		"""clock data out of the adc and return as int"""
-		reading_bytes = self._read_regs(self.REG_RTD_READING, 2)
-		ADC_Code = self._bytes_to_15bit(reading_bytes[0], reading_bytes[1])
-		return ADC_Code
+    def _bytes_to_15bit(self, MSBs_byte, LSBs_byte):
+        """extract a 15bit int from two bytes, MSB justified"""
+        return ((MSBs_byte <<8 | LSBs_byte) >> 1)
+
+
+    def _read_adc(self):
+        """clock data out of the adc and return as int"""
+        reading_bytes = self._read_regs(self.REG_RTD_READING, 2)
+        ADC_Code = self._bytes_to_15bit(reading_bytes[0], reading_bytes[1])
+        return ADC_Code
 
 
 
-	def set_config(self, VBias=0, continuous=0, oneshot=0, threewire=0, faultdetect=0, faultclear=0, filter50Hz=0):
-		"""
-		Overwrite the config register:
-		---------------
-		bit 7: Vbias (1=ON, 0=OFF). Needs to be on in either mode to get new readings.
-		bit 6: Conversion Mode (1=Auto/Continuous, 0=OFF/Manual)
-		bit 5: 1-shot (1=1-shot on, auto cleared)
-		bit 4: 3-wire select (1=3 wire config, 0=2 or 4 wire config)
-		bits 3-2: fault detection cycle (0=none, otherwise see data sheet)
-		bit 1: fault status clear (1=Clear any fault, auto cleared)
-		bit 0: 50/60 Hz filter select (1=50Hz, 0=60Hz)
-		"""
+    def set_config(self, VBias=0, continuous=0, oneshot=0, threewire=0, faultdetect=0, faultclear=0, filter50Hz=0):
+        """
+        Overwrite the config register:
+        ---------------
+        bit 7: Vbias (1=ON, 0=OFF). Needs to be on in either mode to get new readings.
+        bit 6: Conversion Mode (1=Auto/Continuous, 0=OFF/Manual)
+        bit 5: 1-shot (1=1-shot on, auto cleared)
+        bit 4: 3-wire select (1=3 wire config, 0=2 or 4 wire config)
+        bits 3-2: fault detection cycle (0=none, otherwise see data sheet)
+        bit 1: fault status clear (1=Clear any fault, auto cleared)
+        bit 0: 50/60 Hz filter select (1=50Hz, 0=60Hz)
+        """
 
-		new_config_byte = (VBias << 7 | continuous << 6 | oneshot << 5 | threewire << 4 | faultdetect << 2 | faultclear << 1 | filter50Hz)
-		self._write_reg(self.REG_CONFIG_WRITE, new_config_byte)
-
-
-	def oneshot(self):
-		"""Request a single reading without otherwise changing the config."""
-		current_config = self._read_regs(self.REG_CONFIG_READ, 1)[0]
-		new_config = (current_config  | 0b00100000)
-		self._write_reg(self.REG_CONFIG_WRITE, new_config)
+        new_config_byte = (VBias << 7 | continuous << 6 | oneshot << 5 | threewire << 4 | faultdetect << 2 | faultclear << 1 | filter50Hz)
+        self._write_reg(self.REG_CONFIG_WRITE, new_config_byte)
 
 
-	def calculate_resistance(self, adc_code, adc_fullscale=32768):
-		"""Calculate the resistance of the RTD, with R_Ref as full scale """
-		R_RTD = self.R_Ref * adc_code / adc_fullscale
-		return R_RTD
+    def oneshot(self):
+        """Request a single reading without otherwise changing the config."""
+        current_config = self._read_regs(self.REG_CONFIG_READ, 1)[0]
+        new_config = (current_config  | 0b00100000)
+        self._write_reg(self.REG_CONFIG_WRITE, new_config)
+
+
+    def calculate_resistance(self, adc_code, adc_fullscale=32768):
+        """Calculate the resistance of the RTD, with R_Ref as full scale """
+        R_RTD = self.R_Ref * adc_code / adc_fullscale
+        return R_RTD
 
 
 
 # test
 if __name__ == '__main__':
-    
-	import models.pt_rtd
-	MyRTD = models.pt_rtd.PT_RTD(100)
 
-	MyMax = max31865()
-	MyMax.set_config(VBias=1, filter50Hz=1)
-	time.sleep(0.5)
+    import models.pt_rtd
+    MyRTD = models.pt_rtd.PT_RTD(100)
 
-	# test in oneshot mode
-	print("oneshot mode:")
-	for i in range(5):
-		MyMax.oneshot()
-		time.sleep(0.1) # after activating oneshot measurement, conversion takes about 60ms until DATA_READY falls low (=ready). 100ms is safe margin.
-		print(MyRTD(MyMax()))
-		time.sleep(1)
-	time.sleep(1)
+    MyMax = max31865()
+    MyMax.set_config(VBias=1, filter50Hz=1)
+    time.sleep(0.5)
 
-	# test in continuous mode
-	print("continuous mode:")
-	MyMax.set_config(VBias=1, continuous=1, filter50Hz=1)
-	time.sleep(0.5)
+    # test in oneshot mode
+    print("oneshot mode:")
+    for i in range(5):
+        MyMax.oneshot()
+        time.sleep(0.1) # after activating oneshot measurement, conversion takes about 60ms until DATA_READY falls low (=ready). 100ms is safe margin.
+        print(MyRTD(MyMax()))
+        time.sleep(1)
+    time.sleep(1)
 
-	for i in range(5):
-		print(MyRTD(MyMax()))
-		time.sleep(1)
+    # test in continuous mode
+    print("continuous mode:")
+    MyMax.set_config(VBias=1, continuous=1, filter50Hz=1)
+    time.sleep(0.5)
 
-	MyMax.spi.close()
+    for i in range(5):
+        print(MyRTD(MyMax()))
+        time.sleep(1)
+
+    MyMax.spi.close()

--- a/temperature_dc/code/adc/SequentMicrosystemsRTDHAT.py
+++ b/temperature_dc/code/adc/SequentMicrosystemsRTDHAT.py
@@ -36,6 +36,7 @@ RTD_RESISTANCE_ADD = 59
 
 
 def get(stack, channel):
+    """Get temperature directly using simple linear function calculated in HAT hardware"""
     if stack < 0 or stack > 7:
         raise ValueError('Invalid stack level')
     if channel < 1 or channel > 8:
@@ -53,6 +54,7 @@ def get(stack, channel):
 
 
 def getRes(stack, channel):
+    """Get compensated resistance of RTD element, for use in external calculation of temperature"""
     if stack < 0 or stack > 7:
         raise ValueError('Invalid stack level')
     if channel < 1 or channel > 8:
@@ -67,49 +69,3 @@ def getRes(stack, channel):
         raise ValueError('Fail to communicate with the RTD card with message: \"' + str(e) + '\"')
     bus.close()
     return val[0]
-
-
-def get_poly5(stack: int, channel: int) -> float:
-    """
-    Convert RTD reading to Temperature, using 5th order polynomial fit of Temperature as a function of Resistance.
-    This fit provides much improved accuracy through the temperature range of [-200C, 660C], particularly near the high
-    and low ranges, compared to the default linear fitting function baked into the Sequent RTD Data Acquisition
-    Stackable Card for Raspberry Pi.  The coefficients for this fit were developed in a project documented
-    in https://github.com/ewjax/max31865
-
-        temp_C = (c5 * res^5) + (c4 * res^4) + (c3 * res^3) + (c2 * res^2) + (c1 * res) + c0
-
-    :param stack: 0-7, which hat to read
-    :param channel: 1-8, which RTD to read on indicated hat
-    :return: temperature, in celsius
-    """
-
-    # coeffs for 5th order fit
-    c5 = -2.10678E-11
-    c4 = 2.27311E-08
-    c3 = -8.20888E-06
-    c2 = 2.38589E-03
-    c1 = 2.24745E+00
-    c0 = -2.42522E+02
-
-    # get RTD resistance
-    res = getRes(stack, channel)
-
-    # do the math
-    #   Rearrange a bit to make it friendlier (less expensive) to calculate
-    #   temp_C = res ( res ( res ( res ( res * c5 + c4) + c3) + c2) + c1) + c0
-    temp_C = res * c5 + c4
-
-    temp_C *= res
-    temp_C += c3
-
-    temp_C *= res
-    temp_C += c2
-
-    temp_C *= res
-    temp_C += c1
-
-    temp_C *= res
-    temp_C += c0
-
-    return temp_C

--- a/temperature_dc/code/models/pt_rtd.py
+++ b/temperature_dc/code/models/pt_rtd.py
@@ -1,0 +1,55 @@
+"""Model of a Platinum Resistance Temperature Detector (PT-RTD)"""
+
+class PT_RTD:
+
+    def __init__(self, R_0dC=100):
+        self.R_0dC = R_0dC	# The RTD resistance at 0 degrees C. Common standards are 100 and 1000.
+
+
+    def __call__(self, resistance: float) -> float:
+        """shorthand for most common usage"""
+        return self.resistance_to_temperature_poly5(resistance)
+
+
+    def resistance_to_temperature_poly5(self, resistance: float) -> float:
+        """
+        Convert RTD reading to Temperature, using 5th order polynomial fit of Temperature as a function of Resistance.
+        This fit provides much improved accuracy through the temperature range of [-200C, 660C], particularly near the high
+        and low ranges, compared to linear fitting functions. The coefficients for this fit were developed in a project documented
+        in https://github.com/ewjax/max31865
+
+            temp_C = (c5 * res^5) + (c4 * res^4) + (c3 * res^3) + (c2 * res^2) + (c1 * res) + c0
+
+        :param resistance: RTD element resistance after cable compensation
+        :return: temperature, in celsius
+        """
+		
+        # re-scale resistance to 100 ohm nominal
+        resistance *= 100 / self.R_0dC
+
+        # coefficients for 5th order fit at 100 ohm nominal resistance
+        c5 = -2.10678E-11
+        c4 = 2.27311E-08
+        c3 = -8.20888E-06
+        c2 = 2.38589E-03
+        c1 = 2.24745E+00
+        c0 = -2.42522E+02
+
+        # do the math
+        #   Rearrange a bit to make it friendlier (less expensive) to calculate
+        #   temp_C = res ( res ( res ( res ( res * c5 + c4) + c3) + c2) + c1) + c0
+        temp_C = resistance * c5 + c4
+
+        temp_C *= resistance
+        temp_C += c3
+
+        temp_C *= resistance
+        temp_C += c2
+
+        temp_C *= resistance
+        temp_C += c1
+
+        temp_C *= resistance
+        temp_C += c0
+
+        return temp_C

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -37,7 +37,7 @@ import time
 #import adc.MAX31865                        # imported below when class is created
 #import adc.DFRobot_MAX31855                # imported below when class is created
 #import adc.SequentMicrosystemsRTDHAT       # imported below when class is created
-
+#import models.pt_rtd                       # imported below when class is created
 
 logger = logging.getLogger("main.measure.sensor")
 
@@ -130,14 +130,17 @@ class PT100_arduino:
 class PT100_raspi_MAX31865:
     def __init__(self, spi_chip_select=1):
         logger.debug("TemperatureMeasureBuildingBlock- PT100_raspi_MAX31865 created")
-        import adc.MAX31865 as MAX31865
-        self.MyMax = MAX31865.max31865(spi_cs=spi_chip_select)
+        import adc.MAX31865
+        import models.pt_rtd
+        self.MyMax = adc.MAX31865.max31865(spi_cs=spi_chip_select)
         self.MyMax.set_config(VBias=1, continuous=1, filter50Hz=1)
-        self.MyRTD = MAX31865.PT_RTD(100)
+        self.MyRTD = models.pt_rtd.PT_RTD(100) # Create RTD model instance. Unfortunately config is not exposed here to select 100 ohm or 1000 ohm
 
     def get_temperature(self):
         logger.debug("TemperatureMeasureBuildingBlock- PT100_raspi_MAX31865 started")
-        return self.MyRTD(self.MyMax())
+        resistance = self.MyMax()
+        logger.debug(f"MAX31864 reported RTD resistance as {resistance}")
+        return self.MyRTD(resistance) # no need to log temperature as each sample is debug logged in measure.py
 
     def close(self):
         self.MyMax.spi.close()
@@ -147,11 +150,15 @@ class PT100_raspi_MAX31865:
 class PT100_raspi_sequentmicrosystems_HAT:
     def __init__(self, stack=0, channel=1):
         logger.debug("TemperatureMeasureBuildingBlock- PT100_raspi_sequentmicrosystems_HAT created")
-        import adc.SequentMicrosystemsRTDHAT as RTDHAT
-        self.RTD_ADC = RTDHAT
+        import adc.SequentMicrosystemsRTDHAT
+        import models.pt_rtd
+        self.RTD_ADC = adc.SequentMicrosystemsRTDHAT # no class, just get() and getRes() sampling functions
         self.channel = channel # 1-8
         self.stack = stack     # 0-7
+        self.MyRTD = models.pt_rtd.PT_RTD(100) # Sequent RTD HAT only supports 100 ohm
 
     def get_temperature(self):
         logger.debug("TemperatureMeasureBuildingBlock- PT100_raspi_sequentmicrosystems_HAT started on stack " + str(self.stack) + " channel " + str(self.channel))
-        return self.RTD_ADC.get_poly5(self.stack, self.channel)
+        resistance = self.RTD_ADC.getRes(self.stack, self.channel)
+        logger.debug(f"Sequent reported RTD resistance as {resistance}")
+        return self.MyRTD(resistance) # no need to log temperature as each sample is debug logged in measure.py


### PR DESCRIPTION
Corrected reference resistor value for MAX31865.py
  * The development board we had last year had a poorly toleranced reference resistor, but that shouldn't affect the codebase. 

Separated RTD resistance / temperature model from resistance-measuring hardare
  * As opposed to multiple copies of the model, or difference models for the same thing, in each hardware interface. 