### PR TITLE
Remove version from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2"
-
 services:
     timeseries-db:
         extends:


### PR DESCRIPTION
We've all seen
```
WARN[0000] /home/pi/TemperatureMonitoring/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```
so much that we have gone blind to it. Here's getting round to a quick chop. 