### PR TITLE
Feature/multiple w1

### DIFF
--- a/temperature_dc/code/measure.py
+++ b/temperature_dc/code/measure.py
@@ -94,7 +94,7 @@ class TemperatureMeasureBuildingBlock(multiprocessing.Process):
         if self.config['sensing']['adc'] == 'MLX90614':
             sensor = sen.MLX90614()
         elif self.config['sensing']['adc'] == 'W1ThermSensor':
-            sensor = sen.W1Therm()
+            sensor = sen.W1Therm(channel)
         elif self.config['sensing']['adc'] == 'K-type_DFRobot_MAX31855':
             sensor = sen.k_type_DFRobot_MAX31855()
         elif self.config['sensing']['adc'] == 'SHT30':

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -93,10 +93,11 @@ class sht30:
 
 
 class W1Therm:
-    def __init__(self):
+    def __init__(self, channel=0):
         logger.debug("TemperatureMeasureBuildingBlock- w1therm created")
         from w1thermsensor import W1ThermSensor
-        self.sensor = W1ThermSensor()
+        all_sensors_on_bus = W1ThermSensor.get_available_sensors()
+        self.sensor = all_sensors_on_bus[channel]
 
 
     def get_temperature(self):

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -93,7 +93,7 @@ class sht30:
 
 
 class W1Therm:
-    def __init__(self, channel=0):
+    def __init__(self, channel=1):
         logger.debug("TemperatureMeasureBuildingBlock- w1therm created")
         from w1thermsensor import W1ThermSensor
         all_sensors_on_bus = W1ThermSensor.get_available_sensors()

--- a/temperature_dc/code/sensor_select.py
+++ b/temperature_dc/code/sensor_select.py
@@ -97,7 +97,7 @@ class W1Therm:
         logger.debug("TemperatureMeasureBuildingBlock- w1therm created")
         from w1thermsensor import W1ThermSensor
         all_sensors_on_bus = W1ThermSensor.get_available_sensors()
-        self.sensor = all_sensors_on_bus[channel]
+        self.sensor = all_sensors_on_bus[channel - 1] # Accept channel numbers starting at 1 for consistency. Map to zero-indexed list.
 
 
     def get_temperature(self):

--- a/temperature_dc/config/config.toml
+++ b/temperature_dc/config/config.toml
@@ -23,7 +23,7 @@
 
 
     # If your sensor supports multiple measurement channels, select one here:
-    channel = 1
+    #channel = 1
 
 [sampling]
     sample_count = 1

--- a/temperature_dc/config/config.toml
+++ b/temperature_dc/config/config.toml
@@ -23,7 +23,7 @@
 
 
     # If your sensor supports multiple measurement channels, select one here:
-    #channel = 1
+    channel = 1
 
 [sampling]
     sample_count = 1


### PR DESCRIPTION
We previously added support for monitoring multiple RTDs from the same hardware (#29, #30)

During a recent build session there was demand for monitoring multiple of our standard DS18B20 sensors on one pi. We worked it out on the spot! 

My question is what to do about default channel number. ~In the case of this sensor, when there is only one sensor it **must** be  channel 0 (unless we offset it etc). In the case of the Sequent HAT, it's numbering starts at 1 (per the silkscreen). I might comment out the channel number in the config file so each sensor can use a different default.~ I've made it so channel 1 is the default and is always available.