### PR TITLE
Hotfix: specify python base image 3.12

### DIFF
--- a/temperature_dc/Dockerfile
+++ b/temperature_dc/Dockerfile
@@ -20,7 +20,7 @@
 #
 # ----------------------------------------------------------------------
 
-FROM python:3
+FROM python:3.12
 
 COPY ./requirements.txt /
 RUN pip3 install -r requirements.txt


### PR DESCRIPTION
3.13 or just 3 no longer build due to #39