### PR TITLE
Remove [computing] from config.toml

### DIFF
--- a/temperature_dc/config/config.toml
+++ b/temperature_dc/config/config.toml
@@ -29,9 +29,6 @@
     sample_count = 1
     sample_interval = 1
 
-[computing]
-    hardware="Pi4"
-
 [mqtt]
     broker = "mqtt.docker.local"
     port = 1883   #common mqtt ports are 1883 and 8883
@@ -46,3 +43,4 @@
     reconnect.initial = 5 # seconds
     reconnect.backoff = 2 # multiplier
     reconnect.limit = 60 # seconds
+


### PR DESCRIPTION
It's not used anywhere. Removing such fluff to make the transition to sensing-dc as clear as possible. 

Need a release branch to merge this into.